### PR TITLE
fix: entrypoint and java.security files

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -16,8 +16,8 @@ COPY --from=enforcer /etc/sysctl.conf /stage/etc/sysctl.conf
 
 COPY --from=manager /licenses /chroot/licenses/
 COPY --from=manager /usr/local/bin/ /chroot/usr/local/bin/
-COPY --from=manager /usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips /usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips
-COPY --from=manager /entrypoint.sh /entrypoint.sh
+COPY --from=manager /usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips /chroot/usr/lib64/jvm/java-17-openjdk-17/conf/security/java.security.fips
+COPY --from=manager /entrypoint.sh /chroot/entrypoint.sh
 
 #
 # Base image

--- a/supervisord.all.conf
+++ b/supervisord.all.conf
@@ -8,7 +8,7 @@ redirect_stderr=true
 loglevel=debug
 
 [program:manager]
-command=/entrypoint.sh
+command=/bin/bash /entrypoint.sh
 exitcodes=0,143
 
 [program:monitor]


### PR DESCRIPTION
In the previous PR, entrypoint and java.security are not correctly copied.

This commit fixes the issue.