### PR TITLE
update urllib3 to 2.7.0 for fixing vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cmd2==2.3.3
 prettytable==2.5.0
 requests==2.32.4
 six==1.11.0
-urllib3==2.6.3
+urllib3==2.7.0
 setuptools==80.10.2


### PR DESCRIPTION
## Description

Update urllib3 from 2.6.3 to 2.7.0 for fixing  CVE-2026-44431 & CVE-2026-44432